### PR TITLE
Fix the check on the PID of the running yarpdatadumper process.

### DIFF
--- a/src/@Connection/Connection.m
+++ b/src/@Connection/Connection.m
@@ -130,25 +130,17 @@ classdef Connection < handle
     methods(Static=true, Access=protected)
         function status = doesPIDmatchDatadumper(pid)
             % get the matching process (only the command wo the parameters)
-            [status,pidCmdRef] = system(['ps -cp ' num2str(pid)]);
+            [status,pidCmdRef] = system(['ps -cp ' num2str(pid) ' -o command']);
             if status
                 warning('Couldn''t verify the PID');
                 status = false;
                 return;
             end
-            % parse the first 4 columns into a 1x4 cell
-            pidCmdRef_cols     = textscan(pidCmdRef,'%s %s %s %s');
-            % expand cell contents and filter to get the array of cells as follows:
-            % PID CMD
-            % XXX XXXXX
-            pidCmdRef_array    = [pidCmdRef_cols{[1 4]}];
-            % expected PID/CMD to compare to
-            generatedPidCmd_array = {'PID','CMD';num2str(pid),'yarpdatadumper'};
-            similar = cellfun(...
-                @(elem1,elem2) strcmp(elem1,elem2),...
-                pidCmdRef_array(:),generatedPidCmd_array(:),...
-                'UniformOutput',false);
-            status = (sum(~[similar{:}]) == 0);
+            % convert the PID information string into a cell array
+            % {'COMMAND'   }
+            % {'yarpserver'}
+            pidCmdRef_cols = textscan(pidCmdRef,'%s');
+            status = strcmp(pidCmdRef_cols{1}{2},'yarpdatadumper');
         end
     end
 end


### PR DESCRIPTION
fixes https://github.com/robotology-playground/sensors-calib-inertial/issues/10

Checks the data dumper PID against the associated executable name `yarpdatadumper`:
```
[status,pidCmdRef] = system(['ps -cp ' num2str(pid) ' -o command']);
```
`ps`: this command displays information about the running processes.
`-c`: Change the ``command'' column output to just contain the executable name, rather than the full command line.
`-p`: Display information about processes which match the specified process IDs.
`-o command`: Display information associated with the space or comma separated list of keywords specified. Note: command=CMD.