### PR TITLE
Fixed torso calibration matrix and added 3rd dimension (joint acceleration) to friction plots

### DIFF
--- a/src/@MotorPWMcontroller/plotterThreadStartFcn.m
+++ b/src/@MotorPWMcontroller/plotterThreadStartFcn.m
@@ -5,10 +5,12 @@ function plotterThreadStartFcn( obj )
 % Figure parameters
 figTitle = 'Motor velocity to torque model';
 xLabel = 'Motor velocity (degrees/s)';
-yLabel = 'Motor torque (N.m)';
+yLabel = 'Motor acceleration (degrees/s^2)';
+zLabel = 'Motor torque (N.m)';
 obj.tempPlot.units = System.Const.Degrees;
-xRange = [-60,60]; % degrees
-yRange = [-10,10]; % N.m
+xRange = [-60,60]; % degrees/s
+yRange = [-100,100]; % degrees/s^2
+zRange = [-10,10]; % N.m
 
 % units conversion
 obj.tempPlot.convertFromRad = Math.convertFromRadians(obj.tempPlot.units);
@@ -24,9 +26,14 @@ obj.tempPlot.figH = figure('Name',figTitle,'WindowStyle','docked');
 title(figTitle,'Fontsize',16,'FontWeight','bold');
 xlabel(xLabel,'Fontsize',12);
 ylabel(yLabel,'Fontsize',12);
+zlabel(zLabel,'Fontsize',12);
 set(gca,'FontSize',12);
 % obj.tempPlot.figH.CurrentAxes.XLim = xRange;
-% obj.tempPlot.figH.CurrentAxes.YLim = yRange;
+% obj.tempPlot.figH.CurrentAxes.YLim = zRange;
+
+view(45,30); % view(az,el)
+% axis vis3d;
+% axis image;
 
 % grid and hold the figure open for further data input
 grid on;

--- a/src/@MotorPWMcontroller/plotterThreadUpdateFcn.m
+++ b/src/@MotorPWMcontroller/plotterThreadUpdateFcn.m
@@ -5,6 +5,8 @@ function plotterThreadUpdateFcn( obj )
 % units defined in the online plotter
 motorVelDeg = obj.remCtrlBoardRemap.getMotorEncoderSpeeds(obj.pwmCtrledMotor.idx);
 motorVel = obj.tempPlot.convertFromDeg(motorVelDeg);
+motorAccDeg = obj.remCtrlBoardRemap.getMotorEncoderAccelerations(obj.pwmCtrledMotor.idx);
+motorAcc = obj.tempPlot.convertFromDeg(motorAccDeg);
 
 % get the motor torque from the respective coupled joints torques
 cpledJointTorques = obj.remCtrlBoardRemap.getJointTorques(obj.couplingJointIdxes);
@@ -13,9 +15,11 @@ motorTorq = ...
     obj.coupling.Tm2j(:,obj.pwmCtrledMotorBitmapInCoupling)' ...
     * cpledJointTorques(:);
 jointVel = motorVel*obj.coupling.gearboxDqM2Jratios{obj.pwmCtrledMotorBitmapInCoupling};
+jointAcc = obj.coupling.Tj2m(obj.pwmCtrledMotorBitmapInCoupling,:) ...
+    * obj.remCtrlBoardRemap.getEncoderAccelerations(); %motorAcc*obj.coupling.gearboxDqM2Jratios{obj.pwmCtrledMotorBitmapInCoupling};
 
 % plot the quantities
-addpoints(obj.tempPlot.an,jointVel,motorTorq);
+addpoints(obj.tempPlot.an,jointVel,jointAcc,motorTorq);
 drawnow limitrate
 
 end

--- a/src/@MotorPWMcontroller/runPwmEmulPosCtrlMode.m
+++ b/src/@MotorPWMcontroller/runPwmEmulPosCtrlMode.m
@@ -10,7 +10,7 @@ function [ ok ] = runPwmEmulPosCtrlMode( obj,samplingPeriod,timeout )
 obj.ctrllerThreadPeriod = samplingPeriod; % thread period
 aFilter = DSP.IdentityFilter([]);         % define the filter
 % DEBUG
-[obj.pidGains.Ki] = deal(-5);
+[obj.pidGains.Ki] = deal(-6);
 [obj.pidGains.Kp] = deal(-4);
 % DEBUG
 PIDCtrller = DSP.PIDcontroller(...

--- a/src/@RemoteControlBoardRemapper/RemoteControlBoardRemapper.m
+++ b/src/@RemoteControlBoardRemapper/RemoteControlBoardRemapper.m
@@ -126,6 +126,9 @@ classdef RemoteControlBoardRemapper < handle
         % Read motor encoder speeds
         [readEncSpeeds] = getMotorEncoderSpeeds(obj,motorsIdxList);
         
+        % Read motor encoder accelerations
+        [readEncAccelerations] = getMotorEncoderAccelerations(obj,motorsIdxList);
+        
         % Get joints indexes as per the control board remapper mapping
         [jointsIdxList,matchingBitmap] = getJointsMappedIdxes(obj,jointNameList);
         

--- a/src/@RemoteControlBoardRemapper/getMotorEncoderAccelerations.m
+++ b/src/@RemoteControlBoardRemapper/getMotorEncoderAccelerations.m
@@ -1,0 +1,13 @@
+function [readEncAccs] = getMotorEncoderAccelerations(obj,motorsIdxList)
+
+% Get all the encoders values
+imotorencs = obj.driver.viewIMotorEncoders();
+readAllEncodersAccs = yarp.Vector();
+readAllEncodersAccs.resize(length(obj.motorsList));
+imotorencs.getMotorEncoderAccelerations(readAllEncodersAccs.data());
+readAllEncAccs=RemoteControlBoardRemapper.toMatlab(readAllEncodersAccs);
+
+% select sub vector
+readEncAccs=readAllEncAccs(motorsIdxList);
+
+end

--- a/src/@RemoteControlBoardRemapper/getMotorsPids.m
+++ b/src/@RemoteControlBoardRemapper/getMotorsPids.m
@@ -22,6 +22,7 @@ fullscaleVec = cell2mat([fullscaleVec{:}]);
 %     'Kp',double(0),'Kd',double(0),'Ki',double(0),...
 %     'max_int',double(0),'max_output',double(0),'scale',double(0)),[1,length(motorsIdxList)]);
 
+% TO BE FIXED
 for idx = 1:length(motorsIdxList)
     cLikeIdx = idx-1; % C like index
 %     ipids.getPid(pidTypeVocab,cLikeIdx,readPid); % (*)
@@ -32,13 +33,13 @@ for idx = 1:length(motorsIdxList)
 %         'scale',readPid.scale);
     readPidsMatArray(idx) = struct(...
         'Kp',-4,'Kd',0,'Ki',-5,...
-        'max_int',4,'max_output',8,...
+        'max_int',10,'max_output',10,...
         'scale',1);
     
-    % these PID constants were defined for PWM control in dutycycle units, not
-    % fullscale percentage units. So we need to convert these coefficients
-    readPidsMatArray(idx) = structfun(...
-        @(field) field*100/fullscaleVec(idx),readPidsMatArray(idx),'Uniformoutput',false);
+%     % these PID constants were defined for PWM control in dutycycle units, not
+%     % fullscale percentage units. So we need to convert these coefficients
+%     readPidsMatArray(idx) = structfun(...
+%         @(field) field*100/fullscaleVec(idx),readPidsMatArray(idx),'Uniformoutput',false);
     readPidsMatArray(idx).scale = 1;
 end
 

--- a/src/@SensorMeasurementsEstimator/getEstimatedMeasurements2.m
+++ b/src/@SensorMeasurementsEstimator/getEstimatedMeasurements2.m
@@ -1,0 +1,20 @@
+function [ FTsMeas,AccsMeas,GyrosMeas,ThAxAngAccsMeas,ThAxFTsMeas ] = getEstimatedMeasurements2( obj,q,dq,d2q,indexes,gravity )
+%Computes the predicted sensor measurements
+% q      : subset of joints positions vector
+% dq     : subset of joints velocities vector
+% d2q    : subset of joints accelerations vector
+% indexes: mapping of subvector to the full vector of joints
+
+qAll = zeros(obj.dofs,1);
+dqAll = zeros(obj.dofs,1);
+d2qAll = zeros(obj.dofs,1);
+% Set the target joints
+qAll(indexes,1) = q;
+dqAll(indexes,1) = dq;
+d2qAll(indexes,1) = d2q;
+
+% Run the estimation
+[FTsMeas,AccsMeas,GyrosMeas,ThAxAngAccsMeas,ThAxFTsMeas] = obj.getEstimatedMeasurements(qAll,dqAll,d2qAll,gravity);
+
+end
+

--- a/src/models/iCubGenova04/hardwareMechanicalsConfig.m
+++ b/src/models/iCubGenova04/hardwareMechanicalsConfig.m
@@ -82,10 +82,10 @@ right_leg.matrixM2J = {...
 
 % torso parameters
 axisConfig = {...
-    'torso_yaw' 'torso_roll' 'torso_pitch'   % AxisName
-    'torso_m1'  'torso_m2'   'torso_m3'      % MotorName
-    32000       32000        32000           % fullscalePWM
-    -100.00     -100.00      -100.00      }; % Gearbox_M2J
+    'torso_roll' 'torso_pitch' 'torso_yaw'     % AxisName
+    'torso_m1'   'torso_m2'    'torso_m3'      % MotorName
+    32000        32000         32000           % fullscalePWM
+    -100.00      -100.00       -100.00      }; % Gearbox_M2J
 
 torso.jointNames   = axisConfig(1,:);
 torso.motorNames   = axisConfig(2,:);


### PR DESCRIPTION
Fixed torso calibration matrix and added 3rd dimension (joint acceleration) to friction plots.

- add Motor encoder accelerations reading to the RemoteControlBoardRemapper
  (not supported yet on the firmware side),
- workaround getMotorsPids: use hardcoded values since the binded method is
  not working properly,
- add new axis to plotterThreadStartFcn with joint accelerations,
- smal refactoring in SensorMeasurementsEstimator,
- Fixed torso calibration matrix (issue https://github.com/robotology-playground/sensors-calib-inertial/issues/26).